### PR TITLE
Improve schema nesting

### DIFF
--- a/aiosnow/models/common/base.py
+++ b/aiosnow/models/common/base.py
@@ -31,16 +31,16 @@ req_cls_map = {
 class BaseModelMeta(type):
     def __new__(mcs, name: str, bases: tuple, attrs: dict) -> Any:
         attrs["fields"] = fields = {}
-        base_attrs = {}
+        base_members = {}
 
         for base in bases:
-            base_attrs.update(base.__dict__)
+            base_members.update({k: v for k, v in base.__dict__.items() if not isinstance(v, (BaseField, Nested, ModelSchemaMeta))})
             inherited_fields = getattr(base.schema_cls, "_declared_fields")
             fields.update(inherited_fields)
 
-        for k, v in attrs.copy().items():
+        for k, v in attrs.items():
             if isinstance(v, (BaseField, Nested, ModelSchemaMeta)):
-                if k in base_attrs.keys():
+                if k in base_members.keys():
                     raise InvalidFieldName(
                         f"Field :{name}.{k}: conflicts with a base member, name it something else. "
                         f"The Field :attribute: parameter can be used to give a field an alias."

--- a/aiosnow/models/common/base.py
+++ b/aiosnow/models/common/base.py
@@ -34,7 +34,13 @@ class BaseModelMeta(type):
         base_members = {}
 
         for base in bases:
-            base_members.update({k: v for k, v in base.__dict__.items() if not isinstance(v, (BaseField, Nested, ModelSchemaMeta))})
+            base_members.update(
+                {
+                    k: v
+                    for k, v in base.__dict__.items()
+                    if not isinstance(v, (BaseField, Nested, ModelSchemaMeta))
+                }
+            )
             inherited_fields = getattr(base.schema_cls, "_declared_fields")
             fields.update(inherited_fields)
 
@@ -66,7 +72,7 @@ class BaseModel(metaclass=BaseModelMeta):
         self._client = client
         self.fields = dict(self.schema_cls.fields)
         self.schema = self.schema_cls(unknown=marshmallow.EXCLUDE)
-        self.nested_fields = self.schema.nested_fields
+        self.nested_fields = getattr(self.schema, "nested_fields")
         self._primary_key = getattr(self.schema, "_primary_key")
 
     @property

--- a/aiosnow/models/common/schema/base.py
+++ b/aiosnow/models/common/schema/base.py
@@ -20,7 +20,7 @@ class ModelSchemaMeta(marshmallow.schema.SchemaMeta):
     def __new__(mcs, name: str, bases: tuple, attrs: dict) -> Any:
         fields = attrs["fields"] = {}
 
-        for k, v in attrs.copy().items():
+        for k, v in attrs.items():
             if isinstance(v, BaseField):
                 fields[k] = v
                 fields[k].name = k

--- a/aiosnow/models/common/schema/base.py
+++ b/aiosnow/models/common/schema/base.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import Any, Iterable, Tuple, Union
 
 import marshmallow
@@ -93,12 +92,6 @@ class ModelSchema(marshmallow.Schema, metaclass=ModelSchemaMeta):
 
         for key, value in content.items():
             field = self._declared_fields.get(key, None)
-
-            if not field:
-                warnings.warn(
-                    f"Unexpected field in response content: {key}, skipping..."
-                )
-                continue
 
             if isinstance(field, BaseField):
                 if isinstance(value, dict) and {"value", "display_value"} <= set(

--- a/aiosnow/request/base.py
+++ b/aiosnow/request/base.py
@@ -25,7 +25,7 @@ class BaseRequest(ABC):
     ):
         self.api_url = api_url
         self.session = session
-        self.fields = [str(f) for f in fields or []]
+        self.fields = fields or {}
         self.url_segments: List[str] = []
         self.headers_default = {"Content-type": CONTENT_TYPE}
         self._req_id = f"REQ_{hex(int(round(time.time() * 1000)))}"

--- a/aiosnow/request/base.py
+++ b/aiosnow/request/base.py
@@ -21,7 +21,7 @@ class BaseRequest(ABC):
     log = logging.getLogger("aiosnow.request")
 
     def __init__(
-        self, api_url: str, session: Session, fields: list = None,
+        self, api_url: str, session: Session, fields: dict = None,
     ):
         self.api_url = api_url
         self.session = session

--- a/aiosnow/request/get.py
+++ b/aiosnow/request/get.py
@@ -1,6 +1,6 @@
+from time import time
 from typing import Any, Generator, Union
 from urllib.parse import urlparse
-from time import time
 
 from . import methods
 from .base import BaseRequest
@@ -94,7 +94,10 @@ class GetRequest(BaseRequest):
         cache_key = hash(url + "".join(fields or []))
         record_id = urlparse(url).path.split("/")[-1]
 
-        if cache_key in self._cache and self._cache[cache_key][1] > time() - self._cache_secs:
+        if (
+            cache_key in self._cache
+            and self._cache[cache_key][1] > time() - self._cache_secs
+        ):
             self.log.debug(f"Feching {record_id} from cache")
         else:
             request = GetRequest(url, self.session, fields=fields)

--- a/aiosnow/request/get.py
+++ b/aiosnow/request/get.py
@@ -56,13 +56,11 @@ class GetRequest(BaseRequest):
             if not path or not isinstance(path, list):
                 continue
 
-            target_field = path.pop(-1)
+            target_field = path[-1]
             sub_document = document.copy()
 
-            while len(path) > 0:
-                current_field = path[-1]
-                sub_document = sub_document[current_field]
-                path = path[1:]
+            for name in path[:-1]:
+                sub_document = sub_document[name]
 
             if not sub_document.get(target_field):
                 continue
@@ -86,7 +84,7 @@ class GetRequest(BaseRequest):
             content = await self.__expand_document(content)
         elif isinstance(content, list):
             for idx, record in enumerate(content):
-                content[idx] = await self.__expand_document(record)
+                content[idx] = await self._expand_document(record)
 
         return content
 

--- a/aiosnow/request/get.py
+++ b/aiosnow/request/get.py
@@ -1,4 +1,4 @@
-from typing import Any, Union, Generator
+from typing import Any, Generator, Union
 from urllib.parse import urlparse
 
 from . import methods

--- a/tests/model/test_model_schema.py
+++ b/tests/model/test_model_schema.py
@@ -1,7 +1,7 @@
 import pytest
 
 from aiosnow.exceptions import SchemaError
-from aiosnow.models import ModelSchema, fields, Pluck
+from aiosnow.models import ModelSchema, Pluck, fields
 from aiosnow.query.fields import IntegerQueryable, StringQueryable
 
 
@@ -37,10 +37,7 @@ def test_model_schema_dumps_loads():
         test1 = fields.String()
         test2 = fields.Integer()
 
-    dict_obj = dict(
-        test1="test",
-        test2=123
-    )
+    dict_obj = dict(test1="test", test2=123)
 
     json_obj = MainDocument().dumps(dict_obj)
     assert isinstance(json_obj, str)
@@ -55,10 +52,7 @@ def test_model_schema_loads():
         test2 = fields.Integer()
 
     json_obj = """{"test1": "test", "test2": 123}"""
-    dict_obj = dict(
-        test1="test",
-        test2=123
-    )
+    dict_obj = dict(test1="test", test2=123)
 
     assert MainDocument().loads(json_obj) == dict_obj
 
@@ -83,13 +77,7 @@ def test_model_schema_nested():
     }
     """
 
-    dict_obj = dict(
-        test1="test2",
-        related=dict(
-            test2="test1",
-            test3=123
-        )
-    )
+    dict_obj = dict(test1="test2", related=dict(test2="test1", test3=123))
 
     query = MainDocument.related.test2.equals("test123")
     assert str(query) == "related.test2=test123"

--- a/tests/model/test_model_schema.py
+++ b/tests/model/test_model_schema.py
@@ -5,10 +5,6 @@ from aiosnow.models import ModelSchema, Pluck, fields
 from aiosnow.query.fields import IntegerQueryable, StringQueryable
 
 
-def to_mapping(key, value):
-    return dict(value=key, display_value=value)
-
-
 def test_model_schema_field_registration():
     class TestSchema(ModelSchema):
         test1 = fields.String()

--- a/tests/model/test_model_schema.py
+++ b/tests/model/test_model_schema.py
@@ -1,8 +1,8 @@
 import pytest
 
-from aiosnow.models import fields, ModelSchema
-from aiosnow.query.fields import StringQueryable, IntegerQueryable
 from aiosnow.exceptions import SchemaError
+from aiosnow.models import ModelSchema, fields
+from aiosnow.query.fields import IntegerQueryable, StringQueryable
 
 
 def test_model_schema_field_registration():
@@ -18,10 +18,14 @@ def test_model_schema_field_registration():
 
 def test_model_schema_primary_key():
     with pytest.raises(SchemaError):
-        type("TestSchema", (ModelSchema, ), dict(
-            test1=fields.String(is_primary=True),
-            test2=fields.Integer(is_primary=True)
-        ))
+        type(
+            "TestSchema",
+            (ModelSchema,),
+            dict(
+                test1=fields.String(is_primary=True),
+                test2=fields.Integer(is_primary=True),
+            ),
+        )
 
 
 def test_model_schema_nested():
@@ -42,4 +46,3 @@ def test_model_schema_load_response_content():
 
 def test_model_schema_dump_request_payload():
     pass
-

--- a/tests/model/test_model_schema.py
+++ b/tests/model/test_model_schema.py
@@ -1,8 +1,12 @@
 import pytest
 
 from aiosnow.exceptions import SchemaError
-from aiosnow.models import ModelSchema, fields
+from aiosnow.models import ModelSchema, fields, Pluck
 from aiosnow.query.fields import IntegerQueryable, StringQueryable
+
+
+def to_mapping(key, value):
+    return dict(value=key, display_value=value)
 
 
 def test_model_schema_field_registration():
@@ -28,21 +32,71 @@ def test_model_schema_primary_key():
         )
 
 
-def test_model_schema_nested():
-    pass
+def test_model_schema_dumps_loads():
+    class MainDocument(ModelSchema):
+        test1 = fields.String()
+        test2 = fields.Integer()
 
+    dict_obj = dict(
+        test1="test",
+        test2=123
+    )
 
-def test_model_schema_dumps():
-    pass
+    json_obj = MainDocument().dumps(dict_obj)
+    assert isinstance(json_obj, str)
+
+    loaded = MainDocument().loads(json_obj)
+    assert loaded == dict_obj
 
 
 def test_model_schema_loads():
-    pass
+    class MainDocument(ModelSchema):
+        test1 = fields.String()
+        test2 = fields.Integer()
+
+    json_obj = """{"test1": "test", "test2": 123}"""
+    dict_obj = dict(
+        test1="test",
+        test2=123
+    )
+
+    assert MainDocument().loads(json_obj) == dict_obj
 
 
-def test_model_schema_load_response_content():
-    pass
+def test_model_schema_nested():
+    class RelatedDocument(ModelSchema):
+        test2 = fields.String()
+        test3 = fields.Integer(pluck=Pluck.VALUE)
 
+    class MainDocument(ModelSchema):
+        test1 = fields.String(pluck=Pluck.DISPLAY_VALUE)
+        related = RelatedDocument
 
-def test_model_schema_dump_request_payload():
-    pass
+    json_obj = """
+    {
+        "test1": {"value": "test", "display_value": "test2"},
+        "related":
+        {
+            "test2": {"value": "test1", "display_value": "test2"},
+            "test3": {"value": 123, "display_value": "test2"}
+        }
+    }
+    """
+
+    dict_obj = dict(
+        test1="test2",
+        related=dict(
+            test2="test1",
+            test3=123
+        )
+    )
+
+    query = MainDocument.related.test2.equals("test123")
+    assert str(query) == "related.test2=test123"
+
+    main = MainDocument()
+    assert main.loads(json_obj) == dict_obj
+
+    related = main.nested_fields["related"].schema
+    assert isinstance(related, RelatedDocument)
+    assert set(related.fields.keys()) == {"test2", "test3"}

--- a/tests/model/test_model_schema.py
+++ b/tests/model/test_model_schema.py
@@ -1,0 +1,45 @@
+import pytest
+
+from aiosnow.models import fields, ModelSchema
+from aiosnow.query.fields import StringQueryable, IntegerQueryable
+from aiosnow.exceptions import SchemaError
+
+
+def test_model_schema_field_registration():
+    class TestSchema(ModelSchema):
+        test1 = fields.String()
+        test2 = fields.Integer()
+
+    assert isinstance(TestSchema.test1, StringQueryable)
+    assert isinstance(TestSchema.test2, IntegerQueryable)
+    assert isinstance(TestSchema.fields["test1"], fields.String)
+    assert isinstance(TestSchema.fields["test2"], fields.Integer)
+
+
+def test_model_schema_primary_key():
+    with pytest.raises(SchemaError):
+        type("TestSchema", (ModelSchema, ), dict(
+            test1=fields.String(is_primary=True),
+            test2=fields.Integer(is_primary=True)
+        ))
+
+
+def test_model_schema_nested():
+    pass
+
+
+def test_model_schema_dumps():
+    pass
+
+
+def test_model_schema_loads():
+    pass
+
+
+def test_model_schema_load_response_content():
+    pass
+
+
+def test_model_schema_dump_request_payload():
+    pass
+


### PR DESCRIPTION
Adds support for any level of nesting and fixes bugs related to fetching of nested objects and how they are merged with the main document.

*Model declaration*
```python
class ProductCatalogItem(ModelSchema):
    sys_id = aiosnow.fields.String()
    no_order_now = aiosnow.fields.Boolean()
    delivery_time = aiosnow.fields.DateTime()
    sys_name = aiosnow.fields.String()


class HardwareModel(ModelSchema):
    sys_id = aiosnow.fields.String()
    name = aiosnow.fields.String()
    manufacturer = aiosnow.fields.StringMap()
    model_number = aiosnow.fields.String()
    barcode = aiosnow.fields.String()
    power_consumption = aiosnow.fields.Integer()
    rack_units = aiosnow.fields.Integer()
    product_catalog_item = ProductCatalogItem


class Hardware(aiosnow.TableModel):
    sys_id = aiosnow.fields.String(is_primary=True)
    asset_tag = aiosnow.fields.String()
    install_status = aiosnow.fields.StringMap()
    location = aiosnow.fields.String(pluck=Pluck.DISPLAY_VALUE)
    company = aiosnow.fields.StringMap()
    ci = aiosnow.fields.String(pluck=Pluck.DISPLAY_VALUE)
    serial_number = aiosnow.fields.String()
    model = HardwareModel
    sys_class_name = aiosnow.fields.String(pluck=Pluck.DISPLAY_VALUE)
    product_catalog_item = ProductCatalogItem
```

*Response data*
```python
[ { 'asset_tag': 'P1000479',
    'ci': 'MacBook Pro 15"',
    'company': <StringMapping [key=81fdf9ebac1d55eb4cb89f136a082555, value=ACME China]>,
    'install_status': <StringMapping [key=1, value=In use]>,
    'location': '2500 West Daming Road, Shanghai',
    'model': { 'barcode': 'MD318LL/A',
               'manufacturer': <StringMapping [key=b7e9e843c0a80169009a5a485bb2a2b5, value=Apple]>,
               'model_number': 'MD318LL/A',
               'name': 'MacBook Pro 15"',
               'power_consumption': None,
               'product_catalog_item': { 'delivery_time': datetime.datetime(1970, 1, 3, 0, 0),
                                         'no_order_now': False,
                                         'sys_id': '2ab7077237153000158bbfc8bcbe5da9',
                                         'sys_name': 'Apple MacBook Pro 15"'},
               'rack_units': 1,
               'sys_id': 'd501454f1b1310002502fbcd2c071334'},
    'product_catalog_item': { 'delivery_time': datetime.datetime(1970, 1, 3, 0, 0),
                              'no_order_now': False,
                              'sys_id': '2ab7077237153000158bbfc8bcbe5da9',
                              'sys_name': 'Apple MacBook Pro 15"'},
    'serial_number': 'BQP-854-D33246-GH',
    'sys_class_name': 'Hardware',
    'sys_id': 'd501454f1b1310002502fbcd2c071334'}]
```
